### PR TITLE
SHA-416 Disable room export schema

### DIFF
--- a/showcase/build.gradle.kts
+++ b/showcase/build.gradle.kts
@@ -27,10 +27,6 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
-
-        ksp {
-            arg("room.schemaLocation", "$projectDir/schemas")
-        }
     }
 
     val appIdSuffix = resolveAppIdSuffix()


### PR DESCRIPTION
[SHA-416](https://vilua.atlassian.net/browse/SHAD-416)

Seems that after the modification for room to be built via KSP 🎉. It started to export the schema of the db into a .json file, which even when it’s useful for testing or keep track of the current schema, is something it didn’t happen before. 

<img width="570" alt="image" src="https://github.com/SignificoHealth/recco-android-sdk/assets/3531999/a57302ef-322f-45a4-87e8-eca79e77d6c7">

We can enable this back again by adding the following argument to the showcase `build.gradle.kts` (in the `defaultConfig` block) when needed:

```kotlin
  ksp {
      arg("room.schemaLocation", "$projectDir/schemas")
  }
```  

### How to test

1. Build the project outside this PR (with the ksp argument on), notice a `1.json` file in the unstaged changes.
2. Add the argument, clean the project, rebuild. The json shouldn't generate anymore.
