### PR TITLE
[SHAD-574] Fix color missalignments on custom themes

### DIFF
--- a/internal/feature/article/src/main/kotlin/com/recco/internal/feature/article/ArticleScreen.kt
+++ b/internal/feature/article/src/main/kotlin/com/recco/internal/feature/article/ArticleScreen.kt
@@ -134,7 +134,7 @@ private fun ArticleContent(
 
                 Text(
                     text = article.headline,
-                    style = AppTheme.typography.h1.copy(color = AppTheme.colors.onBackground)
+                    style = AppTheme.typography.h1.copy(color = AppTheme.colors.primary)
                 )
                 Spacer(Modifier.height(AppSpacing.dp_32))
 
@@ -149,7 +149,7 @@ private fun ArticleContent(
                 article.lead?.let { lead ->
                     Text(
                         text = lead,
-                        style = AppTheme.typography.body1Bold.copy(color = AppTheme.colors.onBackground)
+                        style = AppTheme.typography.body1Bold.copy(color = AppTheme.colors.primary)
                     )
                     Spacer(Modifier.height(AppSpacing.dp_32))
                 }
@@ -158,7 +158,7 @@ private fun ArticleContent(
                     HtmlText(
                         text = body.replace("\n", "<br/>"),
                         linkClicked = linkClicked,
-                        style = AppTheme.typography.body2.copy(color = AppTheme.colors.onBackground)
+                        style = AppTheme.typography.body2.copy(color = AppTheme.colors.primary)
                     )
                 }
 


### PR DESCRIPTION
## What 

Seem there were some miss-alignments between android and iOS/Web when getting custom theming from backoffice.

https://vilua.atlassian.net/browse/SHAD-574

### Before 

<img width="1000" alt="image" src="https://github.com/SignificoHealth/recco-android-sdk/assets/3531999/be7c7083-58d6-49e5-aa03-b7456ee4f5d5">

### After

<img width="881" alt="image" src="https://github.com/SignificoHealth/recco-android-sdk/assets/3531999/3255e5c7-b48d-4d95-b224-1c8f13b7cc53">



## How

We were using `onBackground` instead `primary` for the text color in the article view. @himanshubansal98 and I traversed the app and seems the only affected part.