### PR TITLE
[SHAD-510] Add ask for notification permission flow

### DIFF
--- a/api/ui/src/main/kotlin/com/recco/api/ui/navigation/AppNavHost.kt
+++ b/api/ui/src/main/kotlin/com/recco/api/ui/navigation/AppNavHost.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
+import com.recco.internal.core.model.recommendation.ContentType
 import com.recco.internal.core.model.recommendation.User
 import com.recco.internal.feature.article.navigation.articleGraph
 import com.recco.internal.feature.article.navigation.navigateToArticle
@@ -39,9 +40,9 @@ internal fun AppNavHost(
         onboardingGraph(navigateToQuestionnaire = navController::navigateToOnboardingQuestionnaire)
         feedGraph(
             navigateToArticle = {
-                navController.navigateToArticle(it)
+//                navController.navigateToArticle(it)
                 // TODO, just for the audio-video-feature development
-//                navController.navigateToMediaDescription(it, ContentType.AUDIO)
+                navController.navigateToMediaDescription(it, ContentType.VIDEO)
             },
             navigateToQuestionnaire = navController::navigateToTopicQuestionnaire,
             navigateToBookmarks = navController::navigateToBookmarks,

--- a/api/ui/src/main/kotlin/com/recco/api/ui/navigation/AppNavHost.kt
+++ b/api/ui/src/main/kotlin/com/recco/api/ui/navigation/AppNavHost.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
-import com.recco.internal.core.model.recommendation.ContentType
 import com.recco.internal.core.model.recommendation.User
 import com.recco.internal.feature.article.navigation.articleGraph
 import com.recco.internal.feature.article.navigation.navigateToArticle
@@ -42,7 +41,7 @@ internal fun AppNavHost(
             navigateToArticle = {
                 navController.navigateToArticle(it)
                 // TODO, just for the audio-video-feature development
-                navController.navigateToMediaDescription(it, ContentType.AUDIO)
+//                navController.navigateToMediaDescription(it, ContentType.AUDIO)
             },
             navigateToQuestionnaire = navController::navigateToTopicQuestionnaire,
             navigateToBookmarks = navController::navigateToBookmarks,

--- a/api/ui/src/main/kotlin/com/recco/api/ui/navigation/AppNavHost.kt
+++ b/api/ui/src/main/kotlin/com/recco/api/ui/navigation/AppNavHost.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
+import com.recco.internal.core.model.recommendation.ContentType
 import com.recco.internal.core.model.recommendation.User
 import com.recco.internal.feature.article.navigation.articleGraph
 import com.recco.internal.feature.article.navigation.navigateToArticle
@@ -41,7 +42,7 @@ internal fun AppNavHost(
             navigateToArticle = {
                 navController.navigateToArticle(it)
                 // TODO, just for the audio-video-feature development
-//                navController.navigateToMediaDescription(it, ContentType.AUDIO)
+                navController.navigateToMediaDescription(it, ContentType.AUDIO)
             },
             navigateToQuestionnaire = navController::navigateToTopicQuestionnaire,
             navigateToBookmarks = navController::navigateToBookmarks,

--- a/internal/core/media/src/main/java/com/recco/internal/core/media/MediaPlayerViewState.kt
+++ b/internal/core/media/src/main/java/com/recco/internal/core/media/MediaPlayerViewState.kt
@@ -147,13 +147,13 @@ fun rememberMediaPlayerStateWithLifecycle(trackItem: TrackItem): MediaPlayerView
         playerView = playerView ?: PlayerView(context).apply { visibility = View.GONE }, // Dummy view for preview
         play = {
             if (!isPlayingState) {
-                if (context.hasPermission(Manifest.permission.POST_NOTIFICATIONS)                ) {
+                if (context.hasPermission(Manifest.permission.POST_NOTIFICATIONS)) {
                     exoPlayer?.let {
                         notificationManager?.showNotificationForPlayer(exoPlayer)
                         exoPlayer.play()
                     }
 
-                } else if (!isNotificationsPermissionGranted) {
+                } else if (!isNotificationsPermissionGranted && trackItem.mediaType == MediaType.AUDIO) {
                     permissionLauncher.askForNotificationPermission()
                 } else {
                     exoPlayer?.play()

--- a/internal/core/media/src/main/java/com/recco/internal/core/media/MediaPlayerViewState.kt
+++ b/internal/core/media/src/main/java/com/recco/internal/core/media/MediaPlayerViewState.kt
@@ -75,7 +75,7 @@ fun rememberMediaPlayerStateWithLifecycle(trackItem: TrackItem): MediaPlayerView
         trackItem = trackItem
     )
 
-    val launcher = rememberLauncherForActivityResult(
+    val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { isGranted ->
         isNotificationsPermissionGranted = isGranted
@@ -154,7 +154,7 @@ fun rememberMediaPlayerStateWithLifecycle(trackItem: TrackItem): MediaPlayerView
                     }
 
                 } else if (!isNotificationsPermissionGranted) {
-                    launcher.askForNotificationPermission()
+                    permissionLauncher.askForNotificationPermission()
                 } else {
                     exoPlayer?.play()
                 }

--- a/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/extensions/Context.kt
+++ b/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/extensions/Context.kt
@@ -2,6 +2,7 @@ package com.recco.internal.core.ui.extensions
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.core.content.ContextCompat
 
@@ -9,4 +10,9 @@ fun Context.openUrlInBrowser(url: String) {
     runCatching {
         ContextCompat.startActivity(this, Intent(Intent.ACTION_VIEW, Uri.parse(url)), null)
     }
+}
+
+fun Context.hasPermission(permission: String): Boolean {
+    return ContextCompat
+        .checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
 }

--- a/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/notifications/RequestNotificationPermission.kt
+++ b/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/notifications/RequestNotificationPermission.kt
@@ -1,0 +1,11 @@
+package com.recco.internal.core.ui.notifications
+
+import android.Manifest
+import android.os.Build
+import androidx.activity.compose.ManagedActivityResultLauncher
+
+fun ManagedActivityResultLauncher<String, Boolean>.askForNotificationPermission() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        launch(Manifest.permission.POST_NOTIFICATIONS)
+    }
+}


### PR DESCRIPTION
> Note, this PR is merging into the main feature branch `sm/audio-video-feature` 
> Note, I'm missing to show a notification explaining why prior requesting permission. Probably to be addressed.

## Links

https://vilua.atlassian.net/browse/SHAD-510

## What

Introduces a flow for asking for notifications permissions (API > 33) for the articles w/ audio, videos and audios

## Sreenshots

### Full Audio Screen

<img src="https://github.com/SignificoHealth/recco-android-sdk/assets/3531999/e827d024-8c5a-4a1c-9b9e-54fbef3c8edb" width="350"/>

### Article w/ Audio

<img src="https://github.com/SignificoHealth/recco-android-sdk/assets/3531999/645eabda-e220-40b2-b8cc-46d41d7d99fd" width="350"/>

### Notification

<img src="https://github.com/SignificoHealth/recco-android-sdk/assets/3531999/961d56ac-a3f0-4144-a602-e88132c0df74" width="350"/>

