### PR TITLE
[SHAD-510] Support Audio & Video on Feed

### DIFF
--- a/internal/core/model/src/main/kotlin/com/recco/internal/core/model/recommendation/Recommendation.kt
+++ b/internal/core/model/src/main/kotlin/com/recco/internal/core/model/recommendation/Recommendation.kt
@@ -8,5 +8,6 @@ data class Recommendation(
     val bookmarked: Boolean,
     val headline: String,
     val imageUrl: String? = null,
-    val imageAlt: String? = null
+    val imageAlt: String? = null,
+    val lengthInSeconds: Int? = null
 )

--- a/internal/core/repository/src/main/kotlin/com/recco/internal/core/repository/RecommendationRepository.kt
+++ b/internal/core/repository/src/main/kotlin/com/recco/internal/core/repository/RecommendationRepository.kt
@@ -25,7 +25,12 @@ import javax.inject.Inject
 class RecommendationRepository @Inject constructor(
     private val api: RecommendationApi
 ) {
-    private val supportedContentTypes = listOf(ContentTypeDTO.ARTICLES, ContentTypeDTO.QUESTIONNAIRES)
+    private val supportedContentTypes = listOf(
+        ContentTypeDTO.ARTICLES,
+        ContentTypeDTO.QUESTIONNAIRES,
+        ContentTypeDTO.AUDIOS,
+        ContentTypeDTO.VIDEOS,
+    )
 
     private val sectionsPipelines = mapOf(
         FeedSectionType.PHYSICAL_ACTIVITY_RECOMMENDATIONS to PipelineStateAware {

--- a/internal/core/repository/src/main/kotlin/com/recco/internal/core/repository/RecommendationRepository.kt
+++ b/internal/core/repository/src/main/kotlin/com/recco/internal/core/repository/RecommendationRepository.kt
@@ -28,8 +28,8 @@ class RecommendationRepository @Inject constructor(
     private val supportedContentTypes = listOf(
         ContentTypeDTO.ARTICLES,
         ContentTypeDTO.QUESTIONNAIRES,
-        ContentTypeDTO.AUDIOS,
-        ContentTypeDTO.VIDEOS,
+//        ContentTypeDTO.AUDIOS, (TODO Backend giving 400s atm)
+//        ContentTypeDTO.VIDEOS,
     )
 
     private val sectionsPipelines = mapOf(

--- a/internal/core/repository/src/main/kotlin/com/recco/internal/core/repository/mapper/RecommendationMapper.kt
+++ b/internal/core/repository/src/main/kotlin/com/recco/internal/core/repository/mapper/RecommendationMapper.kt
@@ -16,6 +16,7 @@ internal fun AppUserRecommendationDTO.asEntity() = Recommendation(
     imageUrl = dynamicImageResizingUrl,
     bookmarked = bookmarked,
     imageAlt = imageAlt,
+    lengthInSeconds = length,
     type = when (type) {
         ARTICLES -> ContentType.ARTICLE
         QUESTIONNAIRES -> ContentType.QUESTIONNAIRE

--- a/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/components/AppRecommendationCard.kt
+++ b/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/components/AppRecommendationCard.kt
@@ -1,7 +1,9 @@
 package com.recco.internal.core.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -13,11 +15,13 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.recco.internal.core.model.recommendation.ContentId
 import com.recco.internal.core.model.recommendation.Recommendation
 import com.recco.internal.core.model.recommendation.Status
@@ -34,7 +38,7 @@ val widthRecommendationCard = 145.dp
 fun AppRecommendationCard(
     recommendation: Recommendation,
     onClick: (ContentId) -> Unit,
-    applyViewedOverlay: Boolean = true
+    applyViewedOverlay: Boolean = true,
 ) {
     Card(
         modifier = Modifier
@@ -62,18 +66,34 @@ fun AppRecommendationCard(
                 loadingAnimationDrawable = loadingCardAnimationDrawable()
             )
 
-            Text(
+            Column(
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.dp_8),
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(AppTheme.colors.background)
                     .padding(AppSpacing.dp_12)
-                    .align(Alignment.BottomCenter),
-                text = recommendation.headline,
-                style = AppTheme.typography.body3,
-                minLines = 2,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
+                    .align(Alignment.BottomCenter)
+            ) {
+                Text(
+                    text = recommendation.headline,
+                    style = AppTheme.typography.body3,
+                    minLines = 2,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                RecommendationTypeRow(
+                    iconSize = 16.dp,
+                    iconSpacing = 4.dp,
+                    textStyle = AppTheme.typography.labelSmall.copy(
+                        color = AppTheme.colors.primary.copy(alpha = 0.6f),
+                        fontSize = 10.sp,
+                    ),
+                    contentType = recommendation.type,
+                    lengthInSeconds = recommendation.lengthInSeconds,
+                    modifier = Modifier.alpha(0.8f)
+                )
+            }
         }
     }
 }

--- a/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/components/RecommendationTypeRow.kt
+++ b/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/components/RecommendationTypeRow.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -12,7 +13,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.recco.internal.core.model.recommendation.ContentType
 import com.recco.internal.core.ui.R
 import com.recco.internal.core.ui.theme.AppSpacing
@@ -20,13 +24,16 @@ import com.recco.internal.core.ui.theme.AppTheme
 
 @Composable
 fun RecommendationTypeRow(
+    modifier: Modifier = Modifier,
+    iconSize: Dp = 24.dp,
+    textStyle: TextStyle = AppTheme.typography.labelSmall,
     contentType: ContentType,
     lengthInSeconds: Int?,
-    modifier: Modifier = Modifier
+    iconSpacing: Dp = AppSpacing.dp_8,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(AppSpacing.dp_8),
+        horizontalArrangement = Arrangement.spacedBy(iconSpacing),
         modifier = modifier
     ) {
         val (iconDrawable, contentTypeString) = when (contentType) {
@@ -49,7 +56,8 @@ fun RecommendationTypeRow(
             Icon(
                 painter = painterResource(id = iconDrawable),
                 tint = AppTheme.colors.primary,
-                contentDescription = null
+                contentDescription = null,
+                modifier = Modifier.size(iconSize)
             )
         }
 
@@ -67,7 +75,7 @@ fun RecommendationTypeRow(
 
             Text(
                 text = contentTypeDurationText,
-                style = AppTheme.typography.labelSmall.copy(color = AppTheme.colors.primary)
+                style = textStyle.copy(color = AppTheme.colors.primary)
             )
         }
     }
@@ -80,7 +88,7 @@ fun RecommendationTypeRowPreview() {
         Surface {
             Column(
                 modifier = Modifier.padding(AppSpacing.dp_16),
-                verticalArrangement = Arrangement.spacedBy(AppSpacing.dp_16)
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.dp_16),
             ) {
                 ContentType.entries.forEach {
                     RecommendationTypeRow(

--- a/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/preview/FeedPreviewProvider.kt
+++ b/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/preview/FeedPreviewProvider.kt
@@ -19,7 +19,7 @@ class FeedPreviewProvider {
             recommendations = if (isRecommendationsLoading) {
                 FlowDataState.Loading
             } else {
-                FlowDataState.Success(List(recommendationsSize) { RecommendationPreviewProvider.data })
+                FlowDataState.Success(List(recommendationsSize) { RecommendationPreviewProvider.ARTICLE })
             },
             feedSection = FeedSection(
                 type = type,

--- a/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/preview/RecommendationPreviewProvider.kt
+++ b/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/preview/RecommendationPreviewProvider.kt
@@ -7,18 +7,40 @@ import com.recco.internal.core.model.recommendation.Recommendation
 import com.recco.internal.core.model.recommendation.Status
 
 class RecommendationPreviewProvider : PreviewParameterProvider<Recommendation> {
-    override val values get() = sequenceOf(data)
+    override val values get() = sequenceOf(ARTICLE, AUDIO, VIDEO)
 
     companion object {
-        val data
-            get() = Recommendation(
-                id = ContentIdPreviewProvider.data,
-                rating = Rating.LIKE,
-                status = Status.VIEWED,
-                headline = "Some headline",
-                bookmarked = true,
-                imageUrl = null,
-                type = ContentType.ARTICLE
-            )
+        val ARTICLE = Recommendation(
+            id = ContentIdPreviewProvider.data,
+            rating = Rating.LIKE,
+            status = Status.VIEWED,
+            headline = "Breathing techniques",
+            bookmarked = true,
+            imageUrl = null,
+            type = ContentType.ARTICLE,
+            lengthInSeconds = 300
+        )
+
+        val AUDIO = Recommendation(
+            id = ContentIdPreviewProvider.data,
+            rating = Rating.LIKE,
+            status = Status.VIEWED,
+            headline = "Catching up with your hobbies",
+            bookmarked = true,
+            imageUrl = null,
+            type = ContentType.AUDIO,
+            lengthInSeconds = 1200
+        )
+
+        val VIDEO = Recommendation(
+            id = ContentIdPreviewProvider.data,
+            rating = Rating.LIKE,
+            status = Status.VIEWED,
+            headline = "Solving your emotions",
+            bookmarked = true,
+            imageUrl = null,
+            type = ContentType.VIDEO,
+            lengthInSeconds = 300
+        )
     }
 }

--- a/internal/feature/bookmark/src/main/kotlin/com/recco/internal/feature/bookmark/BookmarkUIPreviewProvider.kt
+++ b/internal/feature/bookmark/src/main/kotlin/com/recco/internal/feature/bookmark/BookmarkUIPreviewProvider.kt
@@ -11,7 +11,7 @@ internal class BookmarkUIPreviewProvider : PreviewParameterProvider<UiState<Book
             UiState(
                 isLoading = false,
                 data = BookmarkUI(
-                    recommendations = List(10) { RecommendationPreviewProvider.data }
+                    recommendations = List(10) { RecommendationPreviewProvider.ARTICLE }
                 )
             ),
             UiState(isLoading = true),


### PR DESCRIPTION
> Note, this PR is merging into the main feature branch `sm/audio-video-feature` 

## Links

- https://vilua.atlassian.net/browse/SHAD-510
- https://vilua.atlassian.net/browse/SHAD-631
- [figma](https://www.figma.com/file/JwL3YTTqUP0I89l4xypbI9/Recco-App---UI?type=design&node-id=3766-17790&mode=design&t=nqgktC6l3NAkFHjq-0)

## What

- Introduces support for audio & video `ContentTypes` on feed (disabled for now as it's giving 400s from BE)
- Modified the UI according design to show the type of content from feed.

## Screenshots

<img src="https://github.com/SignificoHealth/recco-android-sdk/assets/3531999/0cfe2044-033b-4b68-9721-eaef7c714145" width="300"/>

<img src="https://github.com/SignificoHealth/recco-android-sdk/assets/3531999/798339b5-454f-4469-a278-975baa6c7b4d" width="300"/>
