### PR TITLE
[SHAD-510] Fix Video Glitches

### DIFF
--- a/internal/core/media/src/main/java/com/recco/internal/core/media/MediaPlayerViewState.kt
+++ b/internal/core/media/src/main/java/com/recco/internal/core/media/MediaPlayerViewState.kt
@@ -215,15 +215,18 @@ private fun rememberExoPlayer(
                     setLoadControl(
                         DefaultLoadControl.Builder()
                             .setBufferDurationsMs(
+                                /* minBufferMs = */
                                 5_000,
+                                /* maxBufferMs = */
                                 5_000,
+                                /* bufferForPlaybackMs = */
                                 2_000,
+                                /* bufferForPlaybackAfterRebufferMs = */
                                 2_000
                             ).setPrioritizeTimeOverSizeThresholds(false)
                             .build()
                     )
                 }
-
                 .build()
             player.prepareFor(context, trackItem)
 
@@ -242,7 +245,7 @@ private fun rememberMediaSession(
 ): MediaSession? {
     val context = LocalContext.current
 
-    return remember(exoPlayer, sessionActivityPendingIntent) {
+    return remember {
         if (trackItem.mediaType == MediaType.AUDIO) {
             exoPlayer?.let { player ->
                 sessionActivityPendingIntent?.let { pendingIntent ->

--- a/internal/core/media/src/main/java/com/recco/internal/core/media/MediaPlayerViewState.kt
+++ b/internal/core/media/src/main/java/com/recco/internal/core/media/MediaPlayerViewState.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.session.MediaSession
@@ -209,8 +210,23 @@ private fun rememberExoPlayer(
 
     return remember {
         if (!isInPreviewMode) {
-            val player = ExoPlayer.Builder(context).build()
+            val player = ExoPlayer.Builder(context)
+                .apply {
+                    setLoadControl(
+                        DefaultLoadControl.Builder()
+                            .setBufferDurationsMs(
+                                5_000,
+                                5_000,
+                                2_000,
+                                2_000
+                            ).setPrioritizeTimeOverSizeThresholds(false)
+                            .build()
+                    )
+                }
+
+                .build()
             player.prepareFor(context, trackItem)
+
             player
         } else {
             null
@@ -251,7 +267,7 @@ private fun rememberPlayerView(
     val isInPreviewMode = LocalInspectionMode.current
 
     return if (!isInPreviewMode) {
-        remember(trackItem) {
+        remember {
             val playerView = PlayerView(context).apply {
                 player = exoPlayer
                 controllerAutoShow = false

--- a/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/components/AppScreenStateAware.kt
+++ b/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/components/AppScreenStateAware.kt
@@ -38,7 +38,7 @@ import com.recco.internal.core.ui.R
 import com.recco.internal.core.ui.extensions.noRippleClickable
 import com.recco.internal.core.ui.theme.AppSpacing
 import com.recco.internal.core.ui.theme.AppTheme
-import java.lang.Float.min
+import kotlin.math.min
 
 data class UiState<T>(
     val isLoading: Boolean = true,
@@ -147,12 +147,12 @@ fun <T> AppScreenStateAware(
     } else {
         Box(
             modifier = Modifier
-                .fillMaxSize()
+//                .fillMaxSize()
                 .padding(top = contentPadding.calculateTopPadding())
         ) {
             backgroundContent?.invoke()
 
-            Column(modifier = Modifier.fillMaxSize()) {
+            Column { // (modifier = zModifier.fillMaxSize()) {
                 headerContent?.let {
                     HeaderContent(
                         isFirstLoading = isFirstLoading.value,
@@ -337,7 +337,7 @@ private fun <T> AppScreenStateAwareContent(
             else -> {
                 Box(
                     modifier = Modifier
-                        .fillMaxSize()
+//                        .fillMaxSize()
                         .pullRefresh(pullRefreshState)
                 ) {
                     LaunchedEffect(Unit) {
@@ -345,11 +345,13 @@ private fun <T> AppScreenStateAwareContent(
                         isPullRefreshEnabled.value = true
                     }
 
-                    Column(modifier = Modifier.fillMaxSize()) {
+                    Column(
+//                        modifier = Modifier.fillMaxSize()
+                    ) {
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .weight(1f)
+//                                .weight(1f)
                                 .let {
                                     if (scrollState != null) {
                                         it.verticalScroll(scrollState)

--- a/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/components/AppScreenStateAware.kt
+++ b/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/components/AppScreenStateAware.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.recco.internal.core.ui.R
+import com.recco.internal.core.ui.extensions.applyIf
 import com.recco.internal.core.ui.extensions.noRippleClickable
 import com.recco.internal.core.ui.theme.AppSpacing
 import com.recco.internal.core.ui.theme.AppTheme
@@ -78,6 +79,7 @@ fun <T> AppScreenStateAware(
     isEmpty: Boolean = false,
     retry: () -> Unit,
     refresh: (() -> Unit)? = null,
+    shouldFillMaxSize: Boolean = true,
     loadingHeaderContent: @Composable (() -> Unit)? = null,
     backgroundContent: @Composable (() -> Unit)? = null,
     animatedContentShapeContent: @Composable (() -> Unit)? = null,
@@ -117,7 +119,8 @@ fun <T> AppScreenStateAware(
                 enablePullToRefresh = enablePullToRefresh,
                 avoidClickingWhenRefreshing = avoidClickingWhenRefreshing,
                 footerContent = footerContent,
-                content = content
+                content = content,
+                shouldFillMaxSize = shouldFillMaxSize
             )
 
             headerContent?.let {
@@ -147,12 +150,12 @@ fun <T> AppScreenStateAware(
     } else {
         Box(
             modifier = Modifier
-//                .fillMaxSize()
+                .applyIf(shouldFillMaxSize) { fillMaxSize() }
                 .padding(top = contentPadding.calculateTopPadding())
         ) {
             backgroundContent?.invoke()
 
-            Column { // (modifier = zModifier.fillMaxSize()) {
+            Column(modifier = Modifier.applyIf(shouldFillMaxSize) { fillMaxSize() }) {
                 headerContent?.let {
                     HeaderContent(
                         isFirstLoading = isFirstLoading.value,
@@ -184,6 +187,7 @@ fun <T> AppScreenStateAware(
                     enablePullToRefresh = enablePullToRefresh,
                     avoidClickingWhenRefreshing = avoidClickingWhenRefreshing,
                     footerContent = footerContent,
+                    shouldFillMaxSize = shouldFillMaxSize,
                     content = content
                 )
             }
@@ -274,6 +278,7 @@ private fun <T> AppScreenStateAwareContent(
     uiState: UiState<T>,
     retry: () -> Unit,
     refresh: () -> Unit,
+    shouldFillMaxSize: Boolean,
     enablePullToRefresh: Boolean,
     avoidClickingWhenRefreshing: Boolean,
     loadingHeaderContent: @Composable (() -> Unit)? = null,
@@ -337,7 +342,7 @@ private fun <T> AppScreenStateAwareContent(
             else -> {
                 Box(
                     modifier = Modifier
-//                        .fillMaxSize()
+                        .applyIf(shouldFillMaxSize) { fillMaxSize() }
                         .pullRefresh(pullRefreshState)
                 ) {
                     LaunchedEffect(Unit) {
@@ -346,12 +351,12 @@ private fun <T> AppScreenStateAwareContent(
                     }
 
                     Column(
-//                        modifier = Modifier.fillMaxSize()
+                        modifier = Modifier.applyIf(shouldFillMaxSize) { fillMaxSize() }
                     ) {
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()
-//                                .weight(1f)
+                                .applyIf(shouldFillMaxSize) { weight(1f) }
                                 .let {
                                     if (scrollState != null) {
                                         it.verticalScroll(scrollState)

--- a/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/extensions/ModifierExtensions.kt
+++ b/internal/core/ui/src/main/kotlin/com/recco/internal/core/ui/extensions/ModifierExtensions.kt
@@ -40,6 +40,14 @@ fun Modifier.viewedOverlay(color: Color) = then(
     }
 )
 
+fun Modifier.applyIf(predicate: Boolean, f: Modifier.() -> Modifier): Modifier {
+    return if (predicate) {
+        this.then(f())
+    } else {
+        this
+    }
+}
+
 /**
  * @param index Use for iterable items such as items in a row or column for a sequential effect.
  * @param delayMillis Avoid a non-smooth when the animation starts eagerly during first composition.

--- a/internal/feature/media/src/main/java/com/recco/internal/feature/media/navigation/MediaNavigation.kt
+++ b/internal/feature/media/src/main/java/com/recco/internal/feature/media/navigation/MediaNavigation.kt
@@ -10,6 +10,7 @@ import androidx.navigation.navArgument
 import com.recco.internal.core.model.recommendation.ContentId
 import com.recco.internal.core.model.recommendation.ContentType
 import com.recco.internal.core.ui.navigation.ContentIdNavType
+import com.recco.internal.feature.media.description.MediaDescriptionRoute
 import com.recco.internal.feature.media.player.FullMediaPlayerRoute
 
 internal const val idArg = "id"
@@ -35,12 +36,10 @@ fun NavGraphBuilder.mediaGraph(
                 }
             )
         ) {
-//            MediaDescriptionRoute(
-//                navigateUp = navigateUp,
-//                navigateToMediaPlayer = navigateToMediaPlayer
-//            )
-            FullMediaPlayerRoute(navigateUp)
-
+            MediaDescriptionRoute(
+                navigateUp = navigateUp,
+                navigateToMediaPlayer = navigateToMediaPlayer
+            )
         }
         composable(
             route = MediaPlayerRoute,

--- a/internal/feature/media/src/main/java/com/recco/internal/feature/media/navigation/MediaNavigation.kt
+++ b/internal/feature/media/src/main/java/com/recco/internal/feature/media/navigation/MediaNavigation.kt
@@ -10,7 +10,6 @@ import androidx.navigation.navArgument
 import com.recco.internal.core.model.recommendation.ContentId
 import com.recco.internal.core.model.recommendation.ContentType
 import com.recco.internal.core.ui.navigation.ContentIdNavType
-import com.recco.internal.feature.media.description.MediaDescriptionRoute
 import com.recco.internal.feature.media.player.FullMediaPlayerRoute
 
 internal const val idArg = "id"
@@ -36,10 +35,12 @@ fun NavGraphBuilder.mediaGraph(
                 }
             )
         ) {
-            MediaDescriptionRoute(
-                navigateUp = navigateUp,
-                navigateToMediaPlayer = navigateToMediaPlayer
-            )
+//            MediaDescriptionRoute(
+//                navigateUp = navigateUp,
+//                navigateToMediaPlayer = navigateToMediaPlayer
+//            )
+            FullMediaPlayerRoute(navigateUp)
+
         }
         composable(
             route = MediaPlayerRoute,

--- a/internal/feature/media/src/main/java/com/recco/internal/feature/media/player/MediaPlayerScreen.kt
+++ b/internal/feature/media/src/main/java/com/recco/internal/feature/media/player/MediaPlayerScreen.kt
@@ -45,6 +45,7 @@ import com.recco.internal.core.media.rememberMediaPlayerStateWithLifecycle
 import com.recco.internal.core.model.media.Audio
 import com.recco.internal.core.model.media.Video
 import com.recco.internal.core.model.recommendation.ContentId
+import com.recco.internal.core.model.recommendation.ContentType
 import com.recco.internal.core.model.recommendation.Rating
 import com.recco.internal.core.model.recommendation.UserInteractionRecommendation
 import com.recco.internal.core.ui.R
@@ -113,6 +114,7 @@ private fun MediaPlayerScreen(
         AppScreenStateAware(
             uiState = uiState,
             retry = { onUserInteract(MediaDescriptionUserInteract.Retry) },
+            shouldFillMaxSize = uiState.data?.contentType == ContentType.VIDEO,
             isFloatingFooter = true,
             footerContent = {
 //                userInteractionState?.let {

--- a/internal/feature/media/src/main/java/com/recco/internal/feature/media/player/MediaPlayerScreen.kt
+++ b/internal/feature/media/src/main/java/com/recco/internal/feature/media/player/MediaPlayerScreen.kt
@@ -43,18 +43,17 @@ import androidx.media3.common.util.UnstableApi
 import com.recco.internal.core.media.MediaPlayerViewState
 import com.recco.internal.core.media.rememberMediaPlayerStateWithLifecycle
 import com.recco.internal.core.model.media.Audio
+import com.recco.internal.core.model.media.Video
 import com.recco.internal.core.model.recommendation.ContentId
 import com.recco.internal.core.model.recommendation.Rating
 import com.recco.internal.core.model.recommendation.UserInteractionRecommendation
 import com.recco.internal.core.ui.R
-import com.recco.internal.core.ui.components.AppScreenStateAware
-import com.recco.internal.core.ui.components.AppTopBar
 import com.recco.internal.core.ui.components.AppTopBarDefaults
-import com.recco.internal.core.ui.components.BackIconButton
 import com.recco.internal.core.ui.components.UiState
 import com.recco.internal.core.ui.components.UserInteractionRecommendationCard
 import com.recco.internal.core.ui.theme.AppSpacing
 import com.recco.internal.core.ui.theme.AppTheme
+import com.recco.internal.feature.media.asTrackItem
 import com.recco.internal.feature.media.description.LoadMediaViewModel
 import com.recco.internal.feature.media.description.MediaDescriptionUI
 import com.recco.internal.feature.media.description.MediaDescriptionUserInteract
@@ -92,52 +91,59 @@ private fun MediaPlayerScreen(
     onContentUserInteract: (ContentUserInteract) -> Unit,
     onUserInteract: (MediaDescriptionUserInteract) -> Unit
 ) {
-    val playerState = uiState.data?.trackItem?.let { trackItem ->
-        rememberMediaPlayerStateWithLifecycle(trackItem)
-    }
+//    val playerState = uiState.data?.trackItem?.let { trackItem ->
+//        rememberMediaPlayerStateWithLifecycle(trackItem)
+//    }
 
     Box(
         modifier = Modifier
-            .fillMaxSize()
+//            .fillMaxSize()
             .background(AppTheme.colors.background)
     ) {
-        AppScreenStateAware(
-            uiState = uiState,
-            retry = { onUserInteract(MediaDescriptionUserInteract.Retry) },
-            isFloatingFooter = true,
-            footerContent = {
-                userInteractionState?.let {
-                    AnimatedUserInteractionRecomendationCard(
-                        userInteractionRecommendation = it,
-                        onContentUserInteract = onContentUserInteract,
-                        isVisible = playerState?.areControlsShown == false
-                    )
-                }
-            }
-
-        ) {
-            playerState?.let { state ->
-                uiState.data?.let { mediaDescriptionUi ->
-                    MediaPlayerContent(
-                        playerState = state,
-                        mediaDescriptionUi = mediaDescriptionUi
-                    )
-                }
-            }
-        }
-
-        AppTopBar(
-            title = null,
-            elevation = 0.dp,
-            navigationIcon = {
-                BackIconButton(
-                    onClick = navigateUp,
-                    iconTint = Color.White
+            uiState.data?.let { mediaDescriptionUi ->
+                MediaPlayerContent(
+                    mediaDescriptionUi = mediaDescriptionUi
                 )
-            },
-            backgroundColor = Color.Transparent,
-            actions = { } // No actions on this screen
-        )
+            }
+
+
+//        AppScreenStateAware(
+//            uiState = uiState,
+//            retry = { onUserInteract(MediaDescriptionUserInteract.Retry) },
+//            isFloatingFooter = true,
+//            footerContent = {
+//                userInteractionState?.let {
+//                    AnimatedUserInteractionRecomendationCard(
+//                        userInteractionRecommendation = it,
+//                        onContentUserInteract = onContentUserInteract,
+//                        isVisible = playerState?.areControlsShown == false
+//                    )
+//                }
+//            }
+//
+//        ) {
+//            playerState?.let { state ->
+//                uiState.data?.let { mediaDescriptionUi ->
+//                    MediaPlayerContent(
+//                        playerState = state,
+//                        mediaDescriptionUi = mediaDescriptionUi
+//                    )
+//                }
+//            }
+//        }
+//
+//        AppTopBar(
+//            title = null,
+//            elevation = 0.dp,
+//            navigationIcon = {
+//                BackIconButton(
+//                    onClick = navigateUp,
+//                    iconTint = Color.White
+//                )
+//            },
+//            backgroundColor = Color.Transparent,
+//            actions = { } // No actions on this screen
+//        )
     }
 }
 
@@ -192,26 +198,26 @@ private fun AnimatedUserInteractionRecomendationCard(
 
 @Composable
 fun MediaPlayerContent(
-    playerState: MediaPlayerViewState,
     mediaDescriptionUi: MediaDescriptionUI
 ) {
     when (mediaDescriptionUi) {
         is MediaDescriptionUI.AudioDescriptionUI -> {
             AudioPlayerContent(
-                playerState = playerState,
                 mediaDescriptionUi.audio
             )
         }
         is MediaDescriptionUI.VideoDescriptionUI -> {
-            VideoPlayerContent(playerState = playerState)
+            VideoPlayerContent(mediaDescriptionUi.video)
         }
     }
 }
 
 @Composable
 private fun VideoPlayerContent(
-    playerState: MediaPlayerViewState
+    playerState: Video
 ) {
+    val playerState = rememberMediaPlayerStateWithLifecycle(playerState.asTrackItem())
+
     Box(modifier = Modifier.background(Color.Black)) {
         MediaPlayer(
             playerState = playerState,
@@ -237,9 +243,10 @@ private fun VideoPlayerContent(
 
 @Composable
 private fun AudioPlayerContent(
-    playerState: MediaPlayerViewState,
     audio: Audio
 ) {
+    val playerState = rememberMediaPlayerStateWithLifecycle(audio.asTrackItem())
+
     Box {
         val coroutineScope = rememberCoroutineScope()
 

--- a/internal/feature/media/src/main/java/com/recco/internal/feature/media/player/MediaPlayerScreen.kt
+++ b/internal/feature/media/src/main/java/com/recco/internal/feature/media/player/MediaPlayerScreen.kt
@@ -43,9 +43,7 @@ import androidx.media3.common.util.UnstableApi
 import com.recco.internal.core.media.MediaPlayerViewState
 import com.recco.internal.core.media.rememberMediaPlayerStateWithLifecycle
 import com.recco.internal.core.model.media.Audio
-import com.recco.internal.core.model.media.Video
 import com.recco.internal.core.model.recommendation.ContentId
-import com.recco.internal.core.model.recommendation.ContentType
 import com.recco.internal.core.model.recommendation.Rating
 import com.recco.internal.core.model.recommendation.UserInteractionRecommendation
 import com.recco.internal.core.ui.R
@@ -57,7 +55,6 @@ import com.recco.internal.core.ui.components.UiState
 import com.recco.internal.core.ui.components.UserInteractionRecommendationCard
 import com.recco.internal.core.ui.theme.AppSpacing
 import com.recco.internal.core.ui.theme.AppTheme
-import com.recco.internal.feature.media.asTrackItem
 import com.recco.internal.feature.media.description.LoadMediaViewModel
 import com.recco.internal.feature.media.description.MediaDescriptionUI
 import com.recco.internal.feature.media.description.MediaDescriptionUserInteract
@@ -95,51 +92,37 @@ private fun MediaPlayerScreen(
     onContentUserInteract: (ContentUserInteract) -> Unit,
     onUserInteract: (MediaDescriptionUserInteract) -> Unit
 ) {
-//    val playerState = uiState.data?.trackItem?.let { trackItem ->
-//        rememberMediaPlayerStateWithLifecycle(trackItem)
-//    }
-
     Box(
         modifier = Modifier
-//            .fillMaxSize()
             .background(AppTheme.colors.background)
     ) {
-//            uiState.data?.let { mediaDescriptionUi ->
-//                MediaPlayerContent(
-//                    mediaDescriptionUi = mediaDescriptionUi
-//                )
-//            }
-
+        val playerState = uiState.data?.let {
+            rememberMediaPlayerStateWithLifecycle(it.trackItem)
+        }
 
         AppScreenStateAware(
             uiState = uiState,
             retry = { onUserInteract(MediaDescriptionUserInteract.Retry) },
-            shouldFillMaxSize = uiState.data?.contentType == ContentType.VIDEO,
+            shouldFillMaxSize = false,
             isFloatingFooter = true,
             footerContent = {
-//                userInteractionState?.let {
-//                    AnimatedUserInteractionRecomendationCard(
-//                        userInteractionRecommendation = it,
-//                        onContentUserInteract = onContentUserInteract,
-//                        isVisible = playerState?.areControlsShown == false
-//                    )
-//                }
+                userInteractionState?.let {
+                    AnimatedUserInteractionRecomendationCard(
+                        userInteractionRecommendation = it,
+                        onContentUserInteract = onContentUserInteract,
+                        isVisible = playerState?.areControlsShown == false
+                    )
+                }
             }
-
         ) {
             uiState.data?.let { mediaDescriptionUi ->
-                MediaPlayerContent(
-                    mediaDescriptionUi = mediaDescriptionUi
-                )
+                playerState?.let { state ->
+                    MediaPlayerContent(
+                        mediaPlayerViewState = state,
+                        mediaDescriptionUi = mediaDescriptionUi
+                    )
+                }
             }
-//            playerState?.let { state ->
-//                uiState.data?.let { mediaDescriptionUi ->
-//                    MediaPlayerContent(
-//                        playerState = state,
-//                        mediaDescriptionUi = mediaDescriptionUi
-//                    )
-//                }
-//            }
         }
 
         AppTopBar(
@@ -156,7 +139,7 @@ private fun MediaPlayerScreen(
         )
     }
 }
-//
+
 @Composable
 private fun AnimatedUserInteractionRecomendationCard(
     isVisible: Boolean,
@@ -208,26 +191,26 @@ private fun AnimatedUserInteractionRecomendationCard(
 
 @Composable
 fun MediaPlayerContent(
-    mediaDescriptionUi: MediaDescriptionUI
+    mediaDescriptionUi: MediaDescriptionUI,
+    mediaPlayerViewState: MediaPlayerViewState
 ) {
     when (mediaDescriptionUi) {
         is MediaDescriptionUI.AudioDescriptionUI -> {
             AudioPlayerContent(
-                mediaDescriptionUi.audio
+                mediaDescriptionUi.audio,
+                mediaPlayerViewState
             )
         }
         is MediaDescriptionUI.VideoDescriptionUI -> {
-            VideoPlayerContent(mediaDescriptionUi.video)
+            VideoPlayerContent(mediaPlayerViewState)
         }
     }
 }
 
 @Composable
 private fun VideoPlayerContent(
-    playerState: Video
+    playerState: MediaPlayerViewState
 ) {
-    val playerState = rememberMediaPlayerStateWithLifecycle(playerState.asTrackItem())
-
     Box(modifier = Modifier.background(Color.Black)) {
         MediaPlayer(
             playerState = playerState,
@@ -253,10 +236,9 @@ private fun VideoPlayerContent(
 
 @Composable
 private fun AudioPlayerContent(
-    audio: Audio
+    audio: Audio,
+    playerState: MediaPlayerViewState
 ) {
-    val playerState = rememberMediaPlayerStateWithLifecycle(audio.asTrackItem())
-
     Box {
         val coroutineScope = rememberCoroutineScope()
 

--- a/internal/feature/media/src/main/java/com/recco/internal/feature/media/player/MediaPlayerScreen.kt
+++ b/internal/feature/media/src/main/java/com/recco/internal/feature/media/player/MediaPlayerScreen.kt
@@ -48,7 +48,10 @@ import com.recco.internal.core.model.recommendation.ContentId
 import com.recco.internal.core.model.recommendation.Rating
 import com.recco.internal.core.model.recommendation.UserInteractionRecommendation
 import com.recco.internal.core.ui.R
+import com.recco.internal.core.ui.components.AppScreenStateAware
+import com.recco.internal.core.ui.components.AppTopBar
 import com.recco.internal.core.ui.components.AppTopBarDefaults
+import com.recco.internal.core.ui.components.BackIconButton
 import com.recco.internal.core.ui.components.UiState
 import com.recco.internal.core.ui.components.UserInteractionRecommendationCard
 import com.recco.internal.core.ui.theme.AppSpacing
@@ -100,18 +103,18 @@ private fun MediaPlayerScreen(
 //            .fillMaxSize()
             .background(AppTheme.colors.background)
     ) {
-            uiState.data?.let { mediaDescriptionUi ->
-                MediaPlayerContent(
-                    mediaDescriptionUi = mediaDescriptionUi
-                )
-            }
+//            uiState.data?.let { mediaDescriptionUi ->
+//                MediaPlayerContent(
+//                    mediaDescriptionUi = mediaDescriptionUi
+//                )
+//            }
 
 
-//        AppScreenStateAware(
-//            uiState = uiState,
-//            retry = { onUserInteract(MediaDescriptionUserInteract.Retry) },
-//            isFloatingFooter = true,
-//            footerContent = {
+        AppScreenStateAware(
+            uiState = uiState,
+            retry = { onUserInteract(MediaDescriptionUserInteract.Retry) },
+            isFloatingFooter = true,
+            footerContent = {
 //                userInteractionState?.let {
 //                    AnimatedUserInteractionRecomendationCard(
 //                        userInteractionRecommendation = it,
@@ -119,9 +122,14 @@ private fun MediaPlayerScreen(
 //                        isVisible = playerState?.areControlsShown == false
 //                    )
 //                }
-//            }
-//
-//        ) {
+            }
+
+        ) {
+            uiState.data?.let { mediaDescriptionUi ->
+                MediaPlayerContent(
+                    mediaDescriptionUi = mediaDescriptionUi
+                )
+            }
 //            playerState?.let { state ->
 //                uiState.data?.let { mediaDescriptionUi ->
 //                    MediaPlayerContent(
@@ -130,23 +138,23 @@ private fun MediaPlayerScreen(
 //                    )
 //                }
 //            }
-//        }
-//
-//        AppTopBar(
-//            title = null,
-//            elevation = 0.dp,
-//            navigationIcon = {
-//                BackIconButton(
-//                    onClick = navigateUp,
-//                    iconTint = Color.White
-//                )
-//            },
-//            backgroundColor = Color.Transparent,
-//            actions = { } // No actions on this screen
-//        )
+        }
+
+        AppTopBar(
+            title = null,
+            elevation = 0.dp,
+            navigationIcon = {
+                BackIconButton(
+                    onClick = navigateUp,
+                    iconTint = Color.White
+                )
+            },
+            backgroundColor = Color.Transparent,
+            actions = { } // No actions on this screen
+        )
     }
 }
-
+//
 @Composable
 private fun AnimatedUserInteractionRecomendationCard(
     isVisible: Boolean,


### PR DESCRIPTION
> Note, this PR is merging into the main feature branch `sm/audio-video-feature` 

## Links

- https://vilua.atlassian.net/browse/SHAD-510
- https://vilua.atlassian.net/browse/SHAD-631
- [figma](https://www.figma.com/file/JwL3YTTqUP0I89l4xypbI9/Recco-App---UI?type=design&node-id=3766-17790&mode=design&t=nqgktC6l3NAkFHjq-0)

## What

When testing locally on my device, I noticed a video glitch that made the video to appear weirdly scaled. Surprisingly when locking/unlocking the device made the right aspect ratio to be shown. 

Also found some minor memory optimizations that I'm addressing in this PR as well.

Didn't find the root cause yet, but seems to be something related with the `AndroidView`'composable`, ExoPlayer's `PlayerView` & the `.fillMaxSize()` modifier set in any parent composable.

After lot of debugging, I've found out that disabling `fillMaxSize()` from the outer layout, and letting the `androidView` make the measuring, fixes it. 

I'm not really confortable with this solution, so if prioritized, I'd like to go back to this for a better solution.

## Screenshots 

### Before / After

<img width="385" alt="image" src="https://github.com/SignificoHealth/recco-android-sdk/assets/3531999/85e9f27d-b232-400a-b49f-b1c9d7fbd370">
<img width="385" alt="image" src="https://github.com/SignificoHealth/recco-android-sdk/assets/3531999/a6e5a19c-00f9-42d4-8651-1bf97555bbe4">


