### PR TITLE
[SHAD-510] Adjust Podcast experience

### DIFF
--- a/internal/feature/media/src/main/java/com/recco/internal/feature/media/description/MediaDescriptionScreen.kt
+++ b/internal/feature/media/src/main/java/com/recco/internal/feature/media/description/MediaDescriptionScreen.kt
@@ -252,14 +252,14 @@ private fun VideoDescriptionContent(video: Video) {
 
         HtmlText(
             text = video.description?.replace("\n", "<br/>") ?: "",
-            style = AppTheme.typography.body1
+            style = AppTheme.typography.body1.copy(color = AppTheme.colors.primary)
         )
     }
 }
 
 @Preview
 @Composable
-fun VideoDescriptionScreenPreview(
+fun MediaDescriptionScreenPreview(
     @PreviewParameter(MediaDescriptionUiPreviewProvider::class) uiState: UiState<MediaDescriptionUI>
 ) {
     AppTheme {
@@ -273,3 +273,21 @@ fun VideoDescriptionScreenPreview(
         )
     }
 }
+
+@Preview
+@Composable
+fun MediaDescriptionScreenPreviewDark(
+    @PreviewParameter(MediaDescriptionUiPreviewProvider::class) uiState: UiState<MediaDescriptionUI>
+) {
+    AppTheme(darkTheme = true) {
+        MediaDescriptionScreen(
+            navigateUp = {},
+            uiState = uiState,
+            userInteractionState = null,
+            navigateToMediaPlayer = { _, _ -> },
+            onUserInteract = {},
+            onContentUserInteract = {}
+        )
+    }
+}
+

--- a/internal/feature/media/src/main/java/com/recco/internal/feature/media/player/MediaPlayerScreen.kt
+++ b/internal/feature/media/src/main/java/com/recco/internal/feature/media/player/MediaPlayerScreen.kt
@@ -53,6 +53,7 @@ import com.recco.internal.core.ui.components.AppTopBarDefaults
 import com.recco.internal.core.ui.components.BackIconButton
 import com.recco.internal.core.ui.components.UiState
 import com.recco.internal.core.ui.components.UserInteractionRecommendationCard
+import com.recco.internal.core.ui.extensions.applyIf
 import com.recco.internal.core.ui.theme.AppSpacing
 import com.recco.internal.core.ui.theme.AppTheme
 import com.recco.internal.feature.media.description.LoadMediaViewModel
@@ -244,7 +245,9 @@ private fun AudioPlayerContent(
 
         MediaPlayer(
             playerState = playerState,
-            modifier = Modifier.align(Alignment.Center)
+            modifier = Modifier
+                .align(Alignment.Center)
+                .background(AppTheme.colors.staticDark)
         )
 
         AnimatedVisibility(
@@ -255,20 +258,20 @@ private fun AudioPlayerContent(
             AudioHeader(audio)
         }
 
-        PlayButton(
-            modifier = Modifier.align(Alignment.Center),
-            isPlaying = playerState.isPlaying,
-            onClick = {
-                if (!playerState.isPlaying) {
+        AnimatedVisibility(
+            visible = !playerState.isPlaying,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            modifier = Modifier.align(Alignment.Center)
+        ) {
+            PlayButton(
+                isPlaying = false,
+                onClick = {
                     playerState.play()
-                } else {
-                    playerState.pause()
+                    playerState.playerView?.hideController()
                 }
-                coroutineScope.launch {
-                    playerState.playerView?.showController()
-                }
-            }
-        )
+            )
+        }
     }
 }
 


### PR DESCRIPTION
> Note, this PR is merging into the main feature branch sm/audio-video-feature

## Links
https://vilua.atlassian.net/browse/SHAD-510
https://vilua.atlassian.net/browse/SHAD-631
[figma](https://www.figma.com/file/JwL3YTTqUP0I89l4xypbI9/Recco-App---UI?type=design&node-id=3766-17790&mode=design&t=nqgktC6l3NAkFHjq-0)

## What
Polish the podcast experience, by hiding the play button when media is playing also setting a static dark background.

## Screenshots
<img width="400" alt="Screenshot 2024-02-05 at 12 33 00" src="https://github.com/SignificoHealth/recco-android-sdk/assets/3531999/ce6ed0dd-0aa1-4099-b56e-3c4fa02a8cf0">
<img width="400" alt="Screenshot 2024-02-05 at 12 33 07" src="https://github.com/SignificoHealth/recco-android-sdk/assets/3531999/566591f5-521d-4b2f-aba2-e42f68955301">
